### PR TITLE
Potential fix for code scanning alert no. 1: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "morgan": "^1.10.0",
     "node-fetch": "^2.7.0",
     "pg": "^8.16.3",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "cypress": "^14.5.1",

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const { createOrder, directPayout } = require('./addispay');
+const rateLimit = require('express-rate-limit');
 const app = express();
 const PORT = 3000;
 
@@ -140,7 +141,13 @@ app.get('/cancel', (req, res) => {
   res.redirect('/');
 });
 
-app.get('/error', (req, res) => {
+const errorRateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // Limit each IP to 100 requests per windowMs
+  message: { success: false, error: 'Too many requests, please try again later.' },
+});
+
+app.get('/error', errorRateLimiter, (req, res) => {
   res.sendFile(__dirname + '/public/error.html');
 });
 


### PR DESCRIPTION
Potential fix for [https://github.com/Yidnek-T/CW_Form/security/code-scanning/1](https://github.com/Yidnek-T/CW_Form/security/code-scanning/1)

To fix the issue, we will add rate limiting to the `/error` endpoint using the `express-rate-limit` package. This package allows us to define a maximum number of requests per time window for specific routes. The fix involves:

1. Installing the `express-rate-limit` package.
2. Importing the package into `server.js`.
3. Configuring a rate limiter with appropriate settings (e.g., 100 requests per 15 minutes).
4. Applying the rate limiter middleware specifically to the `/error` route.

This approach ensures that the `/error` endpoint is protected from abuse without affecting other routes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
